### PR TITLE
Add policy constraint for privileged containers

### DIFF
--- a/cluster/constraint.yaml
+++ b/cluster/constraint.yaml
@@ -1,0 +1,10 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPPrivilegedContainer
+metadata:
+  name: psp-privileged-container
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: ["kube-system"]


### PR DESCRIPTION
This constraint denies pods from running with privileged containers.

https://github.com/open-policy-agent/gatekeeper-library/blob/master/library/pod-security-policy/privileged-containers/samples/psp-privileged-container/constraint.yaml